### PR TITLE
auto growing iframe provided by the content given

### DIFF
--- a/template/html_mail.jade
+++ b/template/html_mail.jade
@@ -29,4 +29,8 @@ html
       tr
         td
         td.mail-body
-          iframe(srcdoc=html, scrolling="auto", frameborder="0", style="width:100%;height:100%;")
+          iframe(srcdoc=html, scrolling="auto", frameborder="0", style="width:100%;height:100%;", onload="resizeIframe(this)")
+  script.
+    function resizeIframe(obj) {
+      obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+    }


### PR DESCRIPTION
I was running into issues where the iframe wasn't growing with the content given. When the iframe loads the content, it then sets the appropriate height. This pull request fixed the issue for me.
