### PR TITLE
Using resolved options.dir for attachement path

### DIFF
--- a/lib/browserpreview.js
+++ b/lib/browserpreview.js
@@ -21,7 +21,7 @@ var BrowserPreviewTransport = function(options) {
   EventEmitter.call(this);
   this.name = "BROWSERPREVIEW";
   this.version = pkg.version;
-  this.dir = options.dir || os.tmpdir();
+  this.dir = options.dir ? path.resolve(options.dir) : os.tmpdir();
 };
 util.inherits(BrowserPreviewTransport, EventEmitter);
 


### PR DESCRIPTION
Hi!
I tried to use nodemailer-browserpreview-transport with file attachments.
It is not fail and opens browser fine, but the the attachment URL does not locate a valid file path.
I create this pull request to solve the problem.
Regards

#### How to reproduce the problem

1. Create the following test script (and `mkdir tmp`)

```
const nodemailer = require('nodemailer');

const browserPreviewTransport = require('nodemailer-browserpreview-transport');
const transport = nodemailer.createTransport(
  browserPreviewTransport({
    dir: './tmp'
  })
);

transport.sendMail(
  {
    to: 'you@example.com',
    subject: 'test',
    html: '<body>aaa</body>',
    attachments: [
      {
        filename: 'text.txt',
        content: new Buffer('hello world!', 'utf-8')
      }
    ]
  },
  (err, response) => {
    console.log(err);
    console.log(response);
    process.exit(0);
  }
);
```

2. Run the script, and it will open the browser with the message body
3. Click the attachments file and the browser does not open the contents (Because the output HTML generated with the related path, like below)

```
<tr>
<td class="mail-label">Attachments:</td>
<td><a href="tmp/c70afa2f-fae9-1efb-09e1-ec3cc9c0d344@HOSTNAME.text.txt" target="_blank">text2.txt</a><br></td>
</tr>
```